### PR TITLE
Allow fields to have arrays of associated items.

### DIFF
--- a/publish_with_relations.coffee
+++ b/publish_with_relations.coffee
@@ -20,6 +20,8 @@ Meteor.publishWithRelations = (params) ->
       else
         objKey = mapping.key
         mapFilter._id = obj[mapping.key]
+        if _.isArray(mapFilter._id)
+          mapFilter._id = {$in: mapFilter._id}
       _.extend(mapFilter, mapping.filter)
       _.extend(mapOptions, mapping.options)
       if mapping.mappings


### PR DESCRIPTION
Allow you do do things like

``` js
  Meteor.publishWithRelations({
    handle: this,
    collection: Loops,
    mappings: [{
      collection: Profiles,
      key: 'profileIds'
    }]
  }
```

Where a loop looks like:

``` js
{_id: 'abcd', profileIds: ['xcvb', 'cvbb']}
```
