### PR TITLE
Actually stop subscriptions (!!)

### DIFF
--- a/publish_with_relations.coffee
+++ b/publish_with_relations.coffee
@@ -54,8 +54,8 @@ Meteor.publishWithRelations = (params) ->
       handle.stop() for handle in associations[id]
       pub.removed(collection._name, id)
   pub.ready() unless params._noReady
-
+  
   pub.onStop ->
-    for association in associations
-      handle.stop() for handle in association
+    for id, association of associations
+      handle.stop() for key, handle of association
     collectionHandle.stop()


### PR DESCRIPTION
Hey @erundook,

Due to a mistake in CS looping, we weren't actually stopping observes when the subscription stopped.

This had obvious performance problems ! (To say the least).
