### PR TITLE
bug when reverse flag is not explicitly set as false

### DIFF
--- a/publish_with_relations.coffee
+++ b/publish_with_relations.coffee
@@ -47,7 +47,8 @@ Meteor.publishWithRelations = (params) ->
       doMapping(id, fields, params.mappings)
     changed: (id, fields) ->
       _.each fields, (value, key) ->
-        changedMappings = _.where(params.mappings, {key: key, reverse: false})
+        changedMappings = _.filter params.mappings, (mapping) ->
+          mapping.key is key and not mapping.reverse
         doMapping(id, fields, changedMappings)
       pub.changed(collection._name, id, fields)
     removed: (id) ->


### PR DESCRIPTION
When reverse is undefined, reactive change of mapping won't happen. I think it should also accept undefined since it is in the example in readme.
